### PR TITLE
chore: add deployment scaffolding (local + disabled CI)

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,0 +1,12 @@
+# Copy to .env.deploy.production or .env.deploy.development and fill in.
+# Both files are gitignored — never commit real values.
+
+# Vercel — generate at https://vercel.com/account/tokens
+VERCEL_TOKEN=
+
+# Team / scope slug (run `vercel teams ls` to list). Use your personal username for personal-account deploys.
+VERCEL_SCOPE=piyush-gambhir
+
+# Project ID is auto-stored in .vercel/project.json after `vercel link`.
+# This is here for documentation; deploy.sh doesn't currently need it.
+VERCEL_PROJECT_ID=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+# Vercel deployment workflow.
+#
+# Currently DISABLED for automatic triggers — only fires when manually run from
+# the GitHub UI. To enable on push, uncomment the `push:` block below.
+
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - development
+  # push:
+  #   branches: [release]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'production' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy
+        run: |
+          # Reconstruct the deploy env file from secrets so scripts/deploy.sh works the same locally and in CI.
+          cat > ".env.deploy.${ENV}" <<EOF
+          VERCEL_TOKEN=${VERCEL_TOKEN}
+          VERCEL_SCOPE=${VERCEL_SCOPE}
+          VERCEL_PROJECT_ID=${VERCEL_PROJECT_ID}
+          EOF
+          bash scripts/deploy.sh "$ENV"
+        env:
+          ENV: ${{ inputs.environment || 'production' }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_SCOPE: ${{ secrets.VERCEL_SCOPE }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,16 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*
+.env
+.env.local
+.env.development
+.env.production
+.env.*.local
+.env.deploy
+.env.deploy.production
+.env.deploy.development
+!.env.example
+!.env.deploy.example
 
 # vercel
 .vercel
@@ -34,4 +43,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-.env*.local

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Local Vercel deploy. Run as `bash scripts/deploy.sh [production|development]`.
+#
+# Reads credentials from .env.deploy.<env> (gitignored).
+# See .env.deploy.example for the full list.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ENV="${1:-production}"
+DEPLOY_ENV_FILE=".env.deploy.${ENV}"
+
+if [[ ! -f "$DEPLOY_ENV_FILE" ]]; then
+  echo "error: ${DEPLOY_ENV_FILE} not found in $(pwd)" >&2
+  echo "       copy .env.deploy.example to ${DEPLOY_ENV_FILE} and fill in your values." >&2
+  exit 1
+fi
+
+# Load deploy creds (and don't echo them)
+set -a
+# shellcheck disable=SC1090
+source "$DEPLOY_ENV_FILE"
+set +a
+
+: "${VERCEL_TOKEN:?set VERCEL_TOKEN in ${DEPLOY_ENV_FILE}}"
+: "${VERCEL_SCOPE:?set VERCEL_SCOPE in ${DEPLOY_ENV_FILE}}"
+
+VERCEL_FLAGS=(
+  --token "$VERCEL_TOKEN"
+  --scope "$VERCEL_SCOPE"
+  --yes
+)
+
+if [[ "$ENV" == "production" ]]; then
+  echo "==> Deploying to production via Vercel ($VERCEL_SCOPE)"
+  npx --yes vercel@latest deploy --prod "${VERCEL_FLAGS[@]}"
+else
+  echo "==> Deploying preview to Vercel ($VERCEL_SCOPE)"
+  npx --yes vercel@latest deploy "${VERCEL_FLAGS[@]}"
+fi


### PR DESCRIPTION
Adds the deployment scaffolding template for this repo.

**What's added**
- `scripts/deploy.sh` — local entry point. Reads `.env.deploy.<environment>`. Run as `bash scripts/deploy.sh production` or `development`.
- `.env.deploy.example` — credential template; copy to `.env.deploy.production` (gitignored) and fill in.
- `.github/workflows/deploy.yml` — GitHub Actions workflow. **Disabled** for auto-trigger; only fires via `workflow_dispatch` from the Actions tab. To enable on push, uncomment the commented-out `push:` block.
- `.gitignore` — added `.env.deploy.*` rules with `!*.example` exceptions.

**To enable the workflow:**
1. Set the listed secrets in repo Settings → Secrets and variables → Actions
2. Manually trigger from the Actions tab to validate, then uncomment the `push:` trigger when ready

**Pilot of three** — same template style is being applied to two other repos so the user can compare diffs side by side before bulk-rolling.